### PR TITLE
Nnao45/create test imple

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ test-question-create:
 	fi
 
 .PHONY: test
-test: clean-test test-sql test-question-list test-main
+test: clean-test test-sql test-question-list test-question-create test-main
 
 .PHONY: install
 install:

--- a/src/handler/question-create_test.go
+++ b/src/handler/question-create_test.go
@@ -18,7 +18,6 @@ func TestCreateQuestionRedisInTheTravis(t *testing.T) {
 		mockPool.RedisConn.Close()
 
 		// 一律でflushallはやりすぎか？
-		internalTestRedisConn.Command("FLUSHALL").Expect("OK")
 		flushallRedis(mockPool.RedisConn)
 	}()
 


### PR DESCRIPTION
ローカルコネクション向けの構造体を初期化せずに使おうとしてたからパニック起こしてたっぽいね。