### PR TITLE
refactoring repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,30 +37,30 @@ create-dotenv:
 test-main:
 	go test -v ./src/qicoo-api_test.go
 
-.PHONY: test-sql
-test-sql:
-	go test -v ./src/sql/mysql_test.go ./src/sql/mysql.go
+.PHONY: test-mysqlib
+test-mysqlib:
+	go test -v ./src/mysqlib/mysqlib_test.go ./src/mysqlib/mysqlib.go
 
 .PHONY: test-question-list
 test-question-list:
 	@if test "$(TRAVIS)" = "true" ;\
 		then \
-		go test -v ./src/handler/question-list_test.go ./src/handler/question-list.go ./src/handler/question-sync.go ./src/handler/question-create.go -run TestGetQuestionListInTheTravis ;\
+		go test -v ./src/handler/question-list_test.go ./src/handler/question-handler_test.go ./src/handler/question-list.go ./src/handler/question-sync.go ./src/handler/question-create.go -run TestGetQuestionListInTheTravis ;\
 	else \
-		go test -v ./src/handler/question-list_test.go ./src/handler/question-list.go ./src/handler/question-sync.go ./src/handler/question-create.go -run TestGetQuestionListInTheLocal ;\
+		go test -v ./src/handler/question-list_test.go ./src/handler/question-handler_test.go ./src/handler/question-list.go ./src/handler/question-sync.go ./src/handler/question-create.go -run TestGetQuestionListInTheLocal ;\
 	fi
 
 .PHONY: test-question-create
 test-question-create:
 	@if test "$(TRAVIS)" = "true" ;\
 		then \
-		go test -v ./src/handler/question-create_test.go ./src/handler/question-list_test.go -run TestCreateQuestionRedisInTheTravis ;\
+		go test -v ./src/handler/question-create_test.go ./src/handler/question-handler_test.go ./src/handler/question-list_test.go -run TestCreateQuestionRedisInTheTravis ;\
 	else \
-		go test -v ./src/handler/question-create_test.go ./src/handler/question-list_test.go -run TestCreateQuestionRedisInTheLocal ;\
+		go test -v ./src/handler/question-create_test.go ./src/handler/question-handler_test.go ./src/handler/question-list_test.go -run TestCreateQuestionRedisInTheLocal ;\
 	fi
 
 .PHONY: test
-test: clean-test test-sql test-question-list test-question-create test-main
+test: clean-test test-mysqlib test-question-list test-question-create test-main
 
 .PHONY: install
 install:

--- a/src/handler/question-create.go
+++ b/src/handler/question-create.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/cndjp/qicoo-api/src/sql"
+	"github.com/cndjp/qicoo-api/src/mysqlib"
 	"github.com/go-gorp/gorp"
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
@@ -43,13 +43,13 @@ func QuestionCreateHandler(w http.ResponseWriter, r *http.Request) {
 		"Like: " + strconv.Itoa(question.Like) + "\n"))
 
 	var m *gorp.DbMap
-	db, err := sql.InitMySQL()
+	db, err := mysqlib.InitMySQL()
 	if err != nil {
 		logrus.Error(err)
 		return
 	}
 
-	m = sql.MappingDBandTable(db)
+	m = mysqlib.MappingDBandTable(db)
 	m.AddTableWithName(Question{}, "questions")
 	defer m.Db.Close()
 

--- a/src/handler/question-handler_test.go
+++ b/src/handler/question-handler_test.go
@@ -1,0 +1,129 @@
+package handler_test
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/cndjp/qicoo-api/src/handler"
+	"github.com/gomodule/redigo/redis"
+	"github.com/rafaeljusto/redigomock"
+)
+
+var travisTestRedisConn redis.Conn
+var internalTestRedisConn *redigomock.Conn
+
+const testEventID = "testEventID"
+
+var mockQuestion = handler.Question{
+	ID:        "1",
+	Object:    "question",
+	Username:  "anonymous",
+	EventID:   "0",
+	ProgramID: "1",
+	Comment:   "I am mock",
+	CreatedAt: time.Now(),
+	UpdatedAt: time.Now(),
+	Like:      100000,
+}
+
+var mockMuxVars = handler.MuxVars{
+	EventID: testEventID,
+	Start:   1,
+	End:     100,
+	Sort:    "created_at",
+	Order:   "asc",
+}
+
+type redigoMockConn struct {
+	conn         redis.Conn
+	redisCommand string
+	sortedkey    string
+	questionList handler.QuestionList
+	eventID      string
+}
+
+func (m redigoMockConn) GetRedisConnection() redis.Conn {
+	return m.conn
+}
+
+func (m redigoMockConn) selectRedisCommand() string {
+	return m.redisCommand
+}
+func (m redigoMockConn) selectRedisSortedKey() string {
+	return m.sortedkey
+}
+func (m redigoMockConn) GetQuestionList() handler.QuestionList {
+	return m.questionList
+}
+func (m redigoMockConn) SetQuestion(question handler.Question) error {
+	return nil
+}
+
+func (m redigoMockConn) getQuestionsKey() {
+	return
+}
+
+func (m redigoMockConn) checkRedisKey() {
+	return
+}
+
+func (m redigoMockConn) syncQuestion() string {
+	return m.eventID
+}
+
+func isTravisEnv() bool {
+	if os.Getenv("TRAVIS") == "true" {
+		return true
+	}
+	return false
+}
+
+func TestMain(m *testing.M) {
+	os.Exit(runTests(m))
+}
+
+func runTests(m *testing.M) int {
+	if isTravisEnv() {
+		conn, err := redis.Dial("tcp", "localhost:6379")
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		travisTestRedisConn = conn
+	} else {
+		conn := redigomock.NewConn()
+		defer func() {
+			conn.Clear()
+			err := conn.Close()
+			if err != nil {
+				log.Fatal("runTests: failed launch redis server:", err)
+			}
+		}()
+
+		internalTestRedisConn = conn
+	}
+
+	return m.Run()
+}
+
+func flushallRedis(conn redis.Conn) {
+	if _, err := conn.Do("FLUSHALL"); err != nil {
+		fmt.Println(err)
+	}
+}
+
+func newMockPool() *handler.RedisClient {
+	m := new(handler.RedisClient)
+	if isTravisEnv() {
+		m.RedisConn = travisTestRedisConn
+	} else {
+		m.RedisConn = internalTestRedisConn
+	}
+
+	m.Vars = mockMuxVars
+
+	return m
+}

--- a/src/handler/question-list_test.go
+++ b/src/handler/question-list_test.go
@@ -2,120 +2,11 @@ package handler_test
 
 import (
 	"encoding/json"
-	"fmt"
-	"log"
-	"os"
 	"reflect"
 	"testing"
-	"time"
 
 	"github.com/cndjp/qicoo-api/src/handler"
-	"github.com/gomodule/redigo/redis"
-	"github.com/rafaeljusto/redigomock"
 )
-
-var travisTestRedisConn redis.Conn
-var internalTestRedisConn *redigomock.Conn
-
-const testEventID = "testEventID"
-
-var mockQuestion = handler.Question{
-	ID:        "1",
-	Object:    "question",
-	Username:  "anonymous",
-	EventID:   "0",
-	ProgramID: "1",
-	Comment:   "I am mock",
-	CreatedAt: time.Now(),
-	UpdatedAt: time.Now(),
-	Like:      100000,
-}
-
-var mockMuxVars = handler.MuxVars{
-	EventID: testEventID,
-	Start:   1,
-	End:     100,
-	Sort:    "created_at",
-	Order:   "asc",
-}
-
-type redigoMockConn struct {
-	conn         redis.Conn
-	redisCommand string
-	sortedkey    string
-	questionList handler.QuestionList
-	eventID      string
-}
-
-func (m redigoMockConn) GetRedisConnection() redis.Conn {
-	return m.conn
-}
-
-func (m redigoMockConn) selectRedisCommand() string {
-	return m.redisCommand
-}
-func (m redigoMockConn) selectRedisSortedKey() string {
-	return m.sortedkey
-}
-func (m redigoMockConn) GetQuestionList() handler.QuestionList {
-	return m.questionList
-}
-func (m redigoMockConn) SetQuestion(question handler.Question) error {
-	return nil
-}
-
-func (m redigoMockConn) getQuestionsKey() {
-	return
-}
-
-func (m redigoMockConn) checkRedisKey() {
-	return
-}
-
-func (m redigoMockConn) syncQuestion() string {
-	return m.eventID
-}
-
-func isTravisEnv() bool {
-	if os.Getenv("TRAVIS") == "true" {
-		return true
-	}
-	return false
-}
-
-func TestMain(m *testing.M) {
-	os.Exit(runTests(m))
-}
-
-func runTests(m *testing.M) int {
-	if isTravisEnv() {
-		conn, err := redis.Dial("tcp", "localhost:6379")
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		travisTestRedisConn = conn
-	} else {
-		conn := redigomock.NewConn()
-		defer func() {
-			conn.Clear()
-			err := conn.Close()
-			if err != nil {
-				log.Fatal("runTests: failed launch redis server:", err)
-			}
-		}()
-
-		internalTestRedisConn = conn
-	}
-
-	return m.Run()
-}
-
-func flushallRedis(conn redis.Conn) {
-	if _, err := conn.Do("FLUSHALL"); err != nil {
-		fmt.Println(err)
-	}
-}
 
 func judgeGetQuestionList(ql handler.QuestionList, t *testing.T) {
 	mockComment := ql.Data[0].Comment
@@ -124,19 +15,6 @@ func judgeGetQuestionList(ql handler.QuestionList, t *testing.T) {
 	if !reflect.DeepEqual(expectedComment, mockComment) {
 		t.Errorf("expected %q to eq %q", expectedComment, mockComment)
 	}
-}
-
-func newMockPool() *handler.RedisClient {
-	m := new(handler.RedisClient)
-	if isTravisEnv() {
-		m.RedisConn = travisTestRedisConn
-	} else {
-		m.RedisConn = internalTestRedisConn
-	}
-
-	m.Vars = mockMuxVars
-
-	return m
 }
 
 func TestGetQuestionListInTheTravis(t *testing.T) {

--- a/src/handler/question-sync.go
+++ b/src/handler/question-sync.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/cndjp/qicoo-api/src/sql"
+	"github.com/cndjp/qicoo-api/src/mysqlib"
 	"github.com/go-gorp/gorp"
 	"github.com/sirupsen/logrus"
 )
@@ -24,13 +24,13 @@ func (rc *RedisClient) syncQuestion(eventID string) {
 
 	// DBからデータを取得
 	var m *gorp.DbMap
-	db, err := sql.InitMySQL()
+	db, err := mysqlib.InitMySQL()
 	if err != nil {
 		logrus.Error(err)
 		return
 	}
 
-	m = sql.MappingDBandTable(db)
+	m = mysqlib.MappingDBandTable(db)
 
 	m.AddTableWithName(Question{}, "questions")
 	defer m.Db.Close()

--- a/src/mysqlib/mysqlib.go
+++ b/src/mysqlib/mysqlib.go
@@ -1,13 +1,13 @@
-package sql
+package mysqlib
 
 import (
-	goSQL "database/sql"
+	"database/sql"
 	"os"
 
 	"github.com/go-gorp/gorp"
 )
 
-func InitMySQL() (db *goSQL.DB, err error) {
+func InitMySQL() (db *sql.DB, err error) {
 	dbms := "mysql"
 	user := os.Getenv("DB_USER")
 	password := os.Getenv("DB_PASSWORD")
@@ -16,13 +16,13 @@ func InitMySQL() (db *goSQL.DB, err error) {
 	option := "?parseTime=true"
 
 	connect := user + ":" + password + "@" + protocol + "/" + dbname + option
-	db, err = goSQL.Open(dbms, connect)
+	db, err = sql.Open(dbms, connect)
 
 	return
 }
 
 // InitMySQLDB 環境変数を利用しDBへのConnectionを取得する(sqldriverでconnection poolが実装されているらしい)
-func MappingDBandTable(db *goSQL.DB) *gorp.DbMap {
+func MappingDBandTable(db *sql.DB) *gorp.DbMap {
 	// structの構造体とDBのTableを紐づける
 	return &gorp.DbMap{Db: db, Dialect: gorp.MySQLDialect{}}
 }

--- a/src/mysqlib/mysqlib_test.go
+++ b/src/mysqlib/mysqlib_test.go
@@ -1,14 +1,14 @@
-package sql_test
+package mysqlib_test
 
 import (
-	goSQL "database/sql"
+	"database/sql"
 	"encoding/json"
 	"log"
 	"os"
 	"reflect"
 	"testing"
 
-	"github.com/cndjp/qicoo-api/src/sql"
+	"github.com/cndjp/qicoo-api/src/mysqlib"
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/lestrrat-go/test-mysqld"
 )
@@ -61,7 +61,7 @@ func runTests(m *testing.M) int {
 }
 
 func truncateTables() {
-	db, err := goSQL.Open("mysql", mySQLDataSrc)
+	db, err := sql.Open("mysql", mySQLDataSrc)
 	if err != nil {
 		log.Fatal("db connection error:", err)
 	}
@@ -76,7 +76,7 @@ func truncateTables() {
 func TestMappingDBandTable(t *testing.T) {
 	defer truncateTables()
 
-	db, err := goSQL.Open("mysql", mySQLDataSrc)
+	db, err := sql.Open("mysql", mySQLDataSrc)
 	if err != nil {
 		t.Fatal("db connection error:", err)
 	}
@@ -112,7 +112,7 @@ func TestMappingDBandTable(t *testing.T) {
 	}
 	defer insertRow.Close()
 
-	m := sql.MappingDBandTable(db)
+	m := mysqlib.MappingDBandTable(db)
 	m.AddTableWithName(mock{}, "mock")
 
 	var mks []mock


### PR DESCRIPTION
- テストコードを再構築して共通のコードをわかりやすく分けました。
- sqというライブラリ名がdatabase/sql、mysqlにするとgo-sql-driver/mysqlとかぶるので、mysqlibって名前に。