### PR TITLE
KubernetesのRoot権限チェックの際に、uidの指定が必要だった

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM alpine:3.8
 MAINTAINER sugimount <https://twitter.com/sugimount>
 
-RUN adduser -D qicoo-api
+RUN adduser --uid 1000 -D qicoo-api
 RUN apk --no-cache add tzdata
-USER qicoo-api:qicoo-api
+USER 1000:1000
 COPY ./bin/qicoo-api /home/qicoo-api/qicoo-api
 
 EXPOSE 8080


### PR DESCRIPTION
KubernetesのRoot権限チェックの際に、uidの指定が必要だった