### PR TITLE
SQLのクエリーを投げる際に、.Queryではなく、.Execを使用するように変更

### DIFF
--- a/src/handler/readiness.go
+++ b/src/handler/readiness.go
@@ -37,7 +37,7 @@ func ReadinessFunc(rci RedisConnectionInterface, dmi MySQLDbmapInterface) error 
 	dbmap := dmi.GetMySQLdbmap()
 	defer dbmap.Db.Close()
 
-	_, err := dbmap.Query("SELECT 1;")
+	_, err := dbmap.Exec("SELECT 1;")
 	if err != nil {
 		sugar.Error(err)
 		return err


### PR DESCRIPTION
SQLのクエリーを投げる際に、.Queryではなく、.Execを使用するように変更

以下を参考
https://github.com/go-sql-driver/mysql/issues/111