### PR TITLE
DBconnectionをmainでcloseするように変更

### DIFF
--- a/src/handler/question-create.go
+++ b/src/handler/question-create.go
@@ -90,7 +90,7 @@ func QuestionCreateFunc(rci RedisConnectionInterface, dmi MySQLDbmapInterface, v
 
 	var dbmap *gorp.DbMap
 	dbmap = dmi.GetMySQLdbmap()
-	defer dbmap.Db.Close()
+	//defer dbmap.Db.Close()
 
 	// gorpのトランザクション処理。DBとRedisの両方とも書き込みが出来た場合に、commitする
 	trans, err := dbmap.Begin()
@@ -146,7 +146,7 @@ func SetQuestion(redisConn redis.Conn, dmi MySQLDbmapInterface, v QuestionCreate
 
 	if !yes {
 		dbmap := dmi.GetMySQLdbmap()
-		defer dbmap.Db.Close()
+		//defer dbmap.Db.Close()
 		_, err := syncQuestion(redisConn, dbmap, v.EventID, rks)
 		// 同期にエラー
 		if err != nil {

--- a/src/handler/question-delete.go
+++ b/src/handler/question-delete.go
@@ -88,7 +88,7 @@ func QuestionDeleteFunc(rci RedisConnectionInterface, dmi MySQLDbmapInterface, v
 
 	var dbmap *gorp.DbMap
 	dbmap = dmi.GetMySQLdbmap()
-	defer dbmap.Db.Close()
+	//defer dbmap.Db.Close()
 
 	// gorpのトランザクション処理。DBとRedisの両方とも削除が出来た場合に、commitする
 	trans, err := dbmap.Begin()
@@ -155,7 +155,7 @@ func QuestionDeleteRedis(rci RedisConnectionInterface, dmi MySQLDbmapInterface, 
 
 	if !yes {
 		dbmap := dmi.GetMySQLdbmap()
-		defer dbmap.Db.Close()
+		//defer dbmap.Db.Close()
 		_, err := syncQuestion(redisConn, dbmap, v.EventID, rks)
 		// 同期にエラー
 		if err != nil {

--- a/src/handler/question-like.go
+++ b/src/handler/question-like.go
@@ -70,7 +70,7 @@ func QuestionLikeFunc(rci RedisConnectionInterface, dmi MySQLDbmapInterface, v Q
 	defer sugar.Sync()
 
 	var dbmap = dmi.GetMySQLdbmap()
-	defer dbmap.Db.Close()
+	//defer dbmap.Db.Close()
 	dbmap.TraceOn("", log.New(os.Stdout, "gorptrace: ", log.LstdFlags))
 
 	var question Question
@@ -88,7 +88,7 @@ func QuestionLikeFunc(rci RedisConnectionInterface, dmi MySQLDbmapInterface, v Q
 
 	// RedisのConnection生成
 	redisConn := rci.GetRedisConnection()
-	defer redisConn.Close()
+	//defer redisConn.Close()
 
 	// Keyを生成
 	rks := GetRedisKeys(v.EventID)

--- a/src/handler/readiness.go
+++ b/src/handler/readiness.go
@@ -35,7 +35,7 @@ func ReadinessFunc(rci RedisConnectionInterface, dmi MySQLDbmapInterface) error 
 
 	// DBに接続可能か確認
 	dbmap := dmi.GetMySQLdbmap()
-	defer dbmap.Db.Close()
+	//defer dbmap.Db.Close()
 
 	_, err := dbmap.Exec("SELECT 1;")
 	if err != nil {

--- a/src/mysqlib/mysqlib.go
+++ b/src/mysqlib/mysqlib.go
@@ -34,7 +34,6 @@ func InitDB() error {
 	db, err := sql.Open(dbms, connect)
 
 	if err != nil {
-		sugar.Error(err)
 		return err
 	}
 
@@ -50,7 +49,6 @@ func InitDB() error {
 		if strings.Contains(errmsg, "Can't create database 'qicoo'; database exists") {
 			sugar.Info("qicoo DATABASE exists")
 		} else {
-			sugar.Error(err)
 			return err
 		}
 	}
@@ -76,25 +74,17 @@ func InitDB() error {
 		if strings.Contains(errmsg, "Table 'questions' already exists") {
 			sugar.Info("questions TABLE exists")
 		} else {
-			sugar.Error(err)
 			return err
 		}
 	}
 
-	err = openDB()
-	if err != nil {
-		sugar.Error(err)
-		return err
-	}
-
-	return nil
+	return openDB()
 }
 
 // openDB sql.Openし変数へ格納
 func openDB() error {
 	sugar := loglib.GetSugar()
 	defer sugar.Sync()
-	var err error
 
 	dbms := "mysql"
 	user := os.Getenv("DB_USER")
@@ -104,22 +94,19 @@ func openDB() error {
 	option := "?parseTime=true"
 
 	connect := user + ":" + password + "@" + protocol + "/" + dbname + option
-	qicooDB, err = sql.Open(dbms, connect)
+	qicooDB, err := sql.Open(dbms, connect)
 
 	if err != nil {
-		sugar.Error(err)
 		return err
 	}
 
 	minconns, err := strconv.Atoi(os.Getenv("MYSQL_MAX_IDLE_CONNECTIONS"))
 	if err != nil {
-		sugar.Error(err)
 		return err
 	}
 
 	maxconns, err := strconv.Atoi(os.Getenv("MYSQL_MAX_OPEN_CONNECTIONS"))
 	if err != nil {
-		sugar.Error(err)
 		return err
 	}
 
@@ -133,9 +120,8 @@ func openDB() error {
 func CloseDB() error {
 	sugar := loglib.GetSugar()
 	defer sugar.Sync()
-	var err error
 
-	err = qicooDB.Close()
+	err := qicooDB.Close()
 
 	if err != nil {
 		sugar.Error(err)

--- a/src/qicoo-api.go
+++ b/src/qicoo-api.go
@@ -46,6 +46,8 @@ func init() {
 }
 
 func main() {
+	defer mysqlib.CloseDB()
+
 	r := httprouter.MakeRouter(
 		handler.QuestionCreateHandler,
 		handler.QuestionListHandler,


### PR DESCRIPTION
mysqlibの関数概要
InitDB：初期設定。DatabaseやTableが存在しなければ作成する
openDB：sql.Openしパッケージ変数に格納
CloseDB：上記をmainからCloseするための関数 (パッケージか違うので、直接アクセスできないから関数としてclose)